### PR TITLE
Changing builders permissions depending on server type (main, test, build).

### DIFF
--- a/src/main/java/com/spleefleague/core/SpleefLeague.java
+++ b/src/main/java/com/spleefleague/core/SpleefLeague.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.bukkit.configuration.file.FileConfiguration;
 
 /**
  *
@@ -57,6 +58,7 @@ public class SpleefLeague extends CorePlugin {
     private PortalManager portalManager;
     private DynamicCommandManager dynamicCommandManager;
     private DebuggerHostManager debuggerHostManager;
+    private ServerType serverType;
 
     public SpleefLeague() {
         super("[SpleefLeague]", ChatColor.GRAY + "[" + ChatColor.GOLD + "SpleefLeague" + ChatColor.GRAY + "]" + ChatColor.RESET);
@@ -97,6 +99,8 @@ public class SpleefLeague extends CorePlugin {
         debuggerHostManager = new DebuggerHostManager();
 
         debuggerHostManager.reloadAll(Settings.getList("debugger_hosts"));
+        
+        loadServerType();
     }
 
     @Override
@@ -178,6 +182,19 @@ public class SpleefLeague extends CorePlugin {
             Logger.getLogger(SpleefLeague.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
+    
+    private void loadServerType() {
+        serverType = ServerType.MAIN;
+        FileConfiguration config = getConfig();
+        if(!config.isSet("server_type")) {
+            config.set("server_type", "MAIN");
+            saveConfig();
+            return;
+        }
+        try {
+            serverType = ServerType.valueOf(config.getString("server_type").toUpperCase());
+        }catch(Exception ex) {}
+    }
 
     public Rank getMinimumJoinRank() {
         return minimumJoinRank;
@@ -213,6 +230,10 @@ public class SpleefLeague extends CorePlugin {
 
     public DebuggerHostManager getDebuggerHostManager() {
         return this.debuggerHostManager;
+    }
+    
+    public ServerType getServerType() {
+        return serverType;
     }
 
     // Use the SpawnManager instead.

--- a/src/main/java/com/spleefleague/core/command/commands/fly.java
+++ b/src/main/java/com/spleefleague/core/command/commands/fly.java
@@ -5,7 +5,6 @@
  */
 package com.spleefleague.core.command.commands;
 
-import com.spleefleague.core.chat.Theme;
 import com.spleefleague.core.command.BasicCommand;
 import com.spleefleague.core.player.Rank;
 import com.spleefleague.core.player.SLPlayer;
@@ -21,7 +20,7 @@ import org.bukkit.entity.Player;
 public class fly extends BasicCommand {
 
     public fly(CorePlugin plugin, String name, String usage) {
-        super(plugin, name, usage, Rank.MODERATOR);
+        super(plugin, name, usage, Rank.MODERATOR, Rank.BUILDER);
     }
 
     @Override

--- a/src/main/java/com/spleefleague/core/command/commands/gamemode.java
+++ b/src/main/java/com/spleefleague/core/command/commands/gamemode.java
@@ -9,6 +9,7 @@ import com.spleefleague.core.plugin.CorePlugin;
 import com.spleefleague.core.command.BasicCommand;
 import com.spleefleague.core.player.Rank;
 import com.spleefleague.core.player.SLPlayer;
+import com.spleefleague.core.utils.ServerType;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.command.Command;
@@ -22,7 +23,8 @@ import org.bukkit.entity.Player;
 public class gamemode extends BasicCommand {
 
     public gamemode(CorePlugin plugin, String name, String usage) {
-        super(plugin, name, usage, Rank.MODERATOR, Rank.BUILDER);
+        super(plugin, name, usage, Rank.MODERATOR);
+        setAdditionalRanksDependingOnServerType(ServerType.BUILD, Rank.BUILDER);
     }
 
     @Override

--- a/src/main/java/com/spleefleague/core/command/commands/tp.java
+++ b/src/main/java/com/spleefleague/core/command/commands/tp.java
@@ -11,6 +11,7 @@ import com.spleefleague.core.player.PlayerState;
 import com.spleefleague.core.player.Rank;
 import com.spleefleague.core.player.SLPlayer;
 import com.spleefleague.core.plugin.CorePlugin;
+import com.spleefleague.core.utils.ServerType;
 import org.bukkit.Bukkit;
 import org.bukkit.command.Command;
 import org.bukkit.entity.Player;
@@ -23,7 +24,8 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
 public class tp extends BasicCommand {
 
     public tp(CorePlugin plugin, String name, String usage) {
-        super(plugin, name, usage, Rank.MODERATOR, Rank.BUILDER, Rank.ORGANIZER);
+        super(plugin, name, usage, Rank.MODERATOR, Rank.ORGANIZER);
+        setAdditionalRanksDependingOnServerType(ServerType.BUILD, Rank.BUILDER);
     }
 
     @Override

--- a/src/main/java/com/spleefleague/core/command/commands/tppos.java
+++ b/src/main/java/com/spleefleague/core/command/commands/tppos.java
@@ -9,6 +9,7 @@ import com.spleefleague.core.command.BasicCommand;
 import com.spleefleague.core.player.Rank;
 import com.spleefleague.core.player.SLPlayer;
 import com.spleefleague.core.plugin.CorePlugin;
+import com.spleefleague.core.utils.ServerType;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -23,7 +24,8 @@ import org.bukkit.event.player.PlayerTeleportEvent;
 public class tppos extends BasicCommand {
 
     public tppos(CorePlugin plugin, String name, String usage) {
-        super(plugin, name, usage, Rank.MODERATOR, Rank.BUILDER);
+        super(plugin, name, usage, Rank.MODERATOR);
+        setAdditionalRanksDependingOnServerType(ServerType.BUILD, Rank.BUILDER);
     }
 
     @Override

--- a/src/main/java/com/spleefleague/core/player/SLPlayer.java
+++ b/src/main/java/com/spleefleague/core/player/SLPlayer.java
@@ -2,12 +2,14 @@ package com.spleefleague.core.player;
 
 import com.spleefleague.core.SpleefLeague;
 import com.spleefleague.core.chat.ChatChannel;
+import com.spleefleague.core.chat.Theme;
 import com.spleefleague.core.cosmetics.Collectibles;
 import com.spleefleague.core.io.DBLoad;
 import com.spleefleague.core.io.DBSave;
 import com.spleefleague.core.io.TypeConverter.RankStringConverter;
 import com.spleefleague.core.io.TypeConverter.UUIDStringConverter;
 import com.spleefleague.core.queue.Challenge;
+import com.spleefleague.core.utils.UtilChat;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.GameMode;
@@ -117,6 +119,8 @@ public class SLPlayer extends GeneralPlayer {
     }
     
     public void changeCoins(int delta) {
+        if(delta > 0)
+            UtilChat.s(Theme.INFO, this, "&6+%d coin%s", delta, delta > 1 ? "s" : "");
         setCoins(Math.max(0, coins + delta));
     }
     

--- a/src/main/java/com/spleefleague/core/utils/ServerType.java
+++ b/src/main/java/com/spleefleague/core/utils/ServerType.java
@@ -1,0 +1,11 @@
+package com.spleefleague.core.utils;
+
+/**
+ *
+ * @author 0xC0deBabe <iam@kostya.sexy>
+ */
+public enum ServerType {
+
+    MAIN, TEST, BUILD;
+    
+}


### PR DESCRIPTION
Created common configuration file and added an option 'server_type' to it, which indicates whether that spigot server is of the main servers, build or test server.

Added opportunity to setup additional ranks for commands depending on type of the current server.
Changed builders permissions so they can't use /tp, /tppos & /gm on main servers anymore (but still can on build server) (asked by Toby), gave them possibility to use /fly on main servers.